### PR TITLE
updated ComponentShouldUpdate method to instead look at the stringifi…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ class GoogleMap extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return this.props.coordinates.length !== nextProps.coordinates.length
+      return JSON.stringify(this.props.coordinates) !== JSON.stringify(nextProps.coordinates)
   }
 
   getMarkerId(coordinate) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ class GoogleMap extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-      return JSON.stringify(this.props.coordinates) !== JSON.stringify(nextProps.coordinates)
+    return JSON.stringify(this.props.coordinates) !== JSON.stringify(nextProps.coordinates)
   }
 
   getMarkerId(coordinate) {


### PR DESCRIPTION
updated ComponentShouldUpdate method to instead look at the stringified version of the coordinates instead of the amount of coordinates. 

Why? If you have 3 coordinates, then swap them out with 3 other completely different coordinates, the map will not update because the length of the array is still === 3. 

This update stringifies the props coordinates and compares to strigified nextProps coordinates.